### PR TITLE
[Do not merge] add example illustrating meaningful test output

### DIFF
--- a/pkg/aws/foo.go
+++ b/pkg/aws/foo.go
@@ -1,0 +1,12 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertEqual(t *testing.T, expected string, actual string) {
+	assert.Equal(t, expected, actual, fmt.Sprintf("expected '%s' to equal '%s", expected, actual))
+}

--- a/pkg/aws/foo_test.go
+++ b/pkg/aws/foo_test.go
@@ -1,0 +1,14 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertEqual(t *testing.T) {
+	fakeTest := testing.T{}
+	AssertEqual(t, "a", "b")
+
+	assert.True(t, fakeTest.Failed())
+}


### PR DESCRIPTION
This is an example that seeks to illustrate for
@yardbirdsax how the tests of an `Assert*` func --
which itself performs an `assert.Equal` -- bubble
up meaningful test output describing the exact
assertion failure reason, as illustrated here:

```
$ go test ./...
--- FAIL: TestAssertEqual (0.00s)
    foo.go:11:
                Error Trace:    foo.go:11
                                                        foo_test.go:11
                Error:          Not equal:
                                expected: "a"
                                actual  : "b"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -a
                                +b
                Test:           TestAssertEqual
                Messages:       expected 'a' to equal 'b
    foo_test.go:13:
                Error Trace:    foo_test.go:13
                Error:          Should be true
                Test:           TestAssertEqual
FAIL
FAIL    github.com/hbocodelabs/infratest/pkg/aws        0.792s
FAIL
```