### PR TITLE
ensure mockgen executable installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ test: vet test-fmt
 	go test -cover $(SOURCE) -count=1
 .PHONY: test
 
-mock:
-	~/go/bin/mockgen -source pkg/aws/dax.go -destination mock/dax.go -package mock
-	~/go/bin/mockgen -source pkg/aws/ec2.go -destination mock/ec2.go -package mock
+tools:
+	echo "Installing tools from tools.go"
+	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+.PHONY: tools
+
+mock: tools
+	mockgen -source pkg/aws/dax.go -destination mock/dax.go -package mock
+	mockgen -source pkg/aws/ec2.go -destination mock/ec2.go -package mock
 .PHONY: mock

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -55,12 +56,14 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,7 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/golang/mock/mockgen"
+)


### PR DESCRIPTION
### SUMMARY

Previously, `make mock` assumed...

1. `github.com/golang/mock/mockgen` is installed
2. the `$GOPATH` is `~/go`

This...

1. adds a `tools.go` file for citing `infratest` build-time tooling dependencies, as explained in [this blog post](https://marcofranssen.nl/manage-go-tools-via-go-modules)
2. ensures `mockgen` is installed prior to invoking it via a new `tools` make target that `go install`s everything listed in `tools.go`
3. assumes `mockgen` is present in the `$PATH`, which should be a reasonable assumption given that it's now installed via `go install`

### DEVELOPER IMPACT

* Developers can now invoke `make mock` without having to manually install `mockgen` first.
* `make mock` now works for those developers whose `$GOPATH` is not `~/go`