### PR TITLE
add `AssertRecordExistsInHostedZone` func

### DIFF
--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -4,9 +4,11 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,23 +16,68 @@ import (
 // Typically, it's a [Route53](https://docs.aws.amazon.com/sdk-for-go/api/service/route53/#Route53).
 type Route53Client interface {
 	ListHostedZonesByNameInput(*route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error)
+	ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 }
 
 // AssertRoute53HostedZoneExists asserts whether or not the Route53 zone name
 // it's passed is found amongst those reported by the AWS API.
 func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName string) {
-	found := false
-	zones, err := client.ListHostedZonesByNameInput(&route53.ListHostedZonesByNameInput{
-		DNSName: &zoneName,
+	_, found, err := findZone(client, zoneName)
+
+	assert.Nil(t, err)
+	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
+}
+
+// AssertRoute53RecordExistsInHostedZone asserts whether or not the Route53 record
+// name it's passed exists amongst those associated with the the Route53 zone whose
+// name it's passed.
+func AssertRoute53RecordExistsInHostedZone(t *testing.T, client Route53Client, recordName string, zoneName string) {
+	recordFound := false
+
+	z, zoneFound, err := findZone(client, zoneName)
+
+	assert.Nil(t, err)
+	assert.True(t, zoneFound, fmt.Sprintf("zone '%s' not found", zoneName))
+
+	if !zoneFound {
+		return
+	}
+
+	recs, err := client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
+		StartRecordName: &recordName,
+		HostedZoneId:    z.Id,
 	})
 	assert.Nil(t, err)
 
-	for _, n := range zones.HostedZones {
-		if zoneName == *n.Name {
-			found = true
+	for _, r := range recs.ResourceRecordSets {
+		if strings.ToLower(*r.Name) == strings.ToLower(recordName) {
+			recordFound = true
 			break
 		}
 	}
 
-	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
+	assert.True(t, recordFound, fmt.Sprintf("record '%s' not found", recordName))
+}
+
+func findZone(client Route53Client, zoneName string) (*types.HostedZone, bool, error) {
+	zones, err := client.ListHostedZonesByNameInput(&route53.ListHostedZonesByNameInput{
+		DNSName: &zoneName,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	var zone *types.HostedZone
+	for _, n := range zones.HostedZones {
+		if zoneName == *n.Name {
+			zone = &n
+			break
+		}
+	}
+
+	if zone != nil {
+		return zone, true, nil
+	}
+
+	return nil, false, nil
 }

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -29,11 +29,25 @@ func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName 
 	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
 }
 
+// AssertRecordInput is used as an input to the AssertRecordExistsInHostedZone method.
+type AssertRecordInput struct {
+	// The record name.
+	RecordName string
+
+	// The record type.
+	RecordType types.RRType
+
+	// The zone name.
+	ZoneName string
+}
+
 // AssertRecordExistsInHostedZone asserts whether or not the Route53 record
 // name it's passed exists amongst those associated with the the Route53 zone whose
 // name it's passed.
-func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Route53Client, recordName string, zoneName string) {
+func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Route53Client, recordInput AssertRecordInput) {
 	recordFound := false
+	zoneName := recordInput.ZoneName
+	recordName := recordInput.RecordName
 
 	z, zoneFound, err := findZoneE(client, zoneName)
 
@@ -51,7 +65,7 @@ func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Ro
 	assert.Nil(t, err)
 
 	for _, r := range recs.ResourceRecordSets {
-		if strings.ToLower(*r.Name) == strings.ToLower(recordName) {
+		if strings.ToLower(*r.Name) == strings.ToLower(recordName) && &recordInput.RecordType != nil && r.Type == recordInput.RecordType {
 			recordFound = true
 			break
 		}

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Route53Client is an AWS Route53 API client.
-// Typically, it's a [Route53](https://docs.aws.amazon.com/sdk-for-go/api/service/route53/#Route53).
+// Typically, it's a [Route53](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/route53#Client).
 type Route53Client interface {
 	ListHostedZonesByNameInput(*route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error)
 	ListResourceRecordSets(context.Context, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -22,7 +22,7 @@ type Route53Client interface {
 // AssertRoute53HostedZoneExists asserts whether or not the Route53 zone name
 // it's passed is found amongst those reported by the AWS API.
 func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName string) {
-	_, found, err := findZone(client, zoneName)
+	_, found, err := findZoneE(client, zoneName)
 
 	assert.Nil(t, err)
 	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
@@ -34,7 +34,7 @@ func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName 
 func AssertRecordExistsInHostedZone(t *testing.T, client Route53Client, recordName string, zoneName string) {
 	recordFound := false
 
-	z, zoneFound, err := findZone(client, zoneName)
+	z, zoneFound, err := findZoneE(client, zoneName)
 
 	assert.Nil(t, err)
 	assert.True(t, zoneFound, fmt.Sprintf("zone '%s' not found", zoneName))
@@ -59,7 +59,7 @@ func AssertRecordExistsInHostedZone(t *testing.T, client Route53Client, recordNa
 	assert.True(t, recordFound, fmt.Sprintf("record '%s' not found", recordName))
 }
 
-func findZone(client Route53Client, zoneName string) (*types.HostedZone, bool, error) {
+func findZoneE(client Route53Client, zoneName string) (*types.HostedZone, bool, error) {
 	zones, err := client.ListHostedZonesByNameInput(&route53.ListHostedZonesByNameInput{
 		DNSName: &zoneName,
 	})

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,7 +17,7 @@ import (
 // Typically, it's a [Route53](https://docs.aws.amazon.com/sdk-for-go/api/service/route53/#Route53).
 type Route53Client interface {
 	ListHostedZonesByNameInput(*route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error)
-	ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
+	ListResourceRecordSets(context.Context, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 }
 
 // AssertRoute53HostedZoneExists asserts whether or not the Route53 zone name
@@ -31,7 +32,7 @@ func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName 
 // AssertRecordExistsInHostedZone asserts whether or not the Route53 record
 // name it's passed exists amongst those associated with the the Route53 zone whose
 // name it's passed.
-func AssertRecordExistsInHostedZone(t *testing.T, client Route53Client, recordName string, zoneName string) {
+func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Route53Client, recordName string, zoneName string) {
 	recordFound := false
 
 	z, zoneFound, err := findZoneE(client, zoneName)
@@ -43,7 +44,7 @@ func AssertRecordExistsInHostedZone(t *testing.T, client Route53Client, recordNa
 		return
 	}
 
-	recs, err := client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
+	recs, err := client.ListResourceRecordSets(ctx, &route53.ListResourceRecordSetsInput{
 		StartRecordName: &recordName,
 		HostedZoneId:    z.Id,
 	})

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -28,10 +28,10 @@ func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName 
 	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
 }
 
-// AssertRoute53RecordExistsInHostedZone asserts whether or not the Route53 record
+// AssertRecordExistsInHostedZone asserts whether or not the Route53 record
 // name it's passed exists amongst those associated with the the Route53 zone whose
 // name it's passed.
-func AssertRoute53RecordExistsInHostedZone(t *testing.T, client Route53Client, recordName string, zoneName string) {
+func AssertRecordExistsInHostedZone(t *testing.T, client Route53Client, recordName string, zoneName string) {
 	recordFound := false
 
 	z, zoneFound, err := findZone(client, zoneName)

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -13,23 +14,26 @@ import (
 
 type Route53ClientMock struct {
 	listHostedZonesOutput *route53.ListHostedZonesOutput
-	err                   error
+	listHostedZonesErr    error
+
+	listResourceRecordSetsOutput *route53.ListResourceRecordSetsOutput
+	listResourceRecordSetsErr    error
 }
 
-func NewMockClient(listHostedZonesOutput *route53.ListHostedZonesOutput, err error) Route53ClientMock {
-	return Route53ClientMock{
-		listHostedZonesOutput,
-		err,
-	}
+func (c Route53ClientMock) ListHostedZonesByNameInput(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error) {
+	return c.listHostedZonesOutput, c.listHostedZonesErr
 }
 
-func (c Route53ClientMock) ListHostedZonesByNameInput(listHostedZonesByNameInput *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error) {
-	return c.listHostedZonesOutput, c.err
+func (c Route53ClientMock) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	return c.listResourceRecordSetsOutput, c.listResourceRecordSetsErr
 }
 
 func TestAssertRoute53HostedZoneExists_NotFound(t *testing.T) {
 	fakeTest := &testing.T{}
-	client := NewMockClient(&route53.ListHostedZonesOutput{}, nil)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
+		listHostedZonesErr:    nil,
+	}
 	AssertRoute53HostedZoneExists(fakeTest, client, "bar.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to fail")
@@ -37,7 +41,10 @@ func TestAssertRoute53HostedZoneExists_NotFound(t *testing.T) {
 
 func TestAssertRoute53HostedZoneExists_Error(t *testing.T) {
 	fakeTest := &testing.T{}
-	client := NewMockClient(&route53.ListHostedZonesOutput{}, errors.New("some error"))
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
+		listHostedZonesErr:    errors.New("some error"),
+	}
 	AssertRoute53HostedZoneExists(fakeTest, client, "foo.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to fail")
@@ -46,14 +53,145 @@ func TestAssertRoute53HostedZoneExists_Error(t *testing.T) {
 func TestAssertRoute53HostedZoneExists_Found(t *testing.T) {
 	fakeTest := &testing.T{}
 	name := "foo.com"
-	client := NewMockClient(&route53.ListHostedZonesOutput{
-		HostedZones: []types.HostedZone{
-			types.HostedZone{
-				Name: &name,
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &name,
+				},
 			},
 		},
-	}, nil)
+		listHostedZonesErr: nil,
+	}
 	AssertRoute53HostedZoneExists(fakeTest, client, name)
 
 	assert.False(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to pass")
+}
+
+func TestAssertRoute53RecordExistsInHostedZone_Found(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &zoneName,
+				},
+			},
+		},
+		listHostedZonesErr: nil,
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{
+				types.ResourceRecordSet{
+					Name: &recordName,
+				},
+			},
+		},
+		listResourceRecordSetsErr: nil,
+	}
+
+	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+
+	assert.False(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to pass")
+}
+
+func TestAssertRoute53RecordExistsInHostedZone_RecordNotFound(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &zoneName,
+				},
+			},
+		},
+		listHostedZonesErr: nil,
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{},
+		},
+		listResourceRecordSetsErr: nil,
+	}
+
+	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+
+	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+}
+
+func TestAssertRoute53RecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &zoneName,
+				},
+			},
+		},
+		listHostedZonesErr: nil,
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{},
+		},
+		listResourceRecordSetsErr: errors.New("some error"),
+	}
+
+	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+
+	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+}
+
+func TestAssertRoute53RecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{},
+		},
+		listHostedZonesErr: nil,
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{
+				types.ResourceRecordSet{
+					Name: &recordName,
+				},
+			},
+		},
+		listResourceRecordSetsErr: nil,
+	}
+
+	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+
+	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+}
+
+func TestAssertRoute53RecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &zoneName,
+				},
+			},
+		},
+		listHostedZonesErr: errors.New("some error"),
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{
+				types.ResourceRecordSet{
+					Name: &recordName,
+				},
+			},
+		},
+		listResourceRecordSetsErr: nil,
+	}
+
+	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+
+	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
 }

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -92,7 +92,10 @@ func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		ZoneName:   zoneName,
+	})
 
 	assert.False(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to pass")
 }
@@ -116,7 +119,43 @@ func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		ZoneName:   zoneName,
+	})
+
+	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
+}
+
+func TestAssertRecordExistsInHostedZone_RecordTypeNotFound(t *testing.T) {
+	fakeTest := &testing.T{}
+	zoneName := "foo.com"
+	recordName := fmt.Sprintf("foo.%s", zoneName)
+	client := Route53ClientMock{
+		listHostedZonesOutput: &route53.ListHostedZonesOutput{
+			HostedZones: []types.HostedZone{
+				types.HostedZone{
+					Name: &zoneName,
+				},
+			},
+		},
+		listHostedZonesErr: nil,
+		listResourceRecordSetsOutput: &route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{
+				types.ResourceRecordSet{
+					Name: &recordName,
+					Type: types.RRTypeA,
+				},
+			},
+		},
+		listResourceRecordSetsErr: nil,
+	}
+
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		RecordType: types.RRTypeSoa,
+		ZoneName:   zoneName,
+	})
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -140,7 +179,10 @@ func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.
 		listResourceRecordSetsErr: errors.New("some error"),
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		ZoneName:   zoneName,
+	})
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -164,7 +206,10 @@ func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		ZoneName:   zoneName,
+	})
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -192,7 +237,10 @@ func TestAssertRecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *test
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+		RecordName: recordName,
+		ZoneName:   zoneName,
+	})
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -68,7 +68,7 @@ func TestAssertRoute53HostedZoneExists_Found(t *testing.T) {
 	assert.False(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to pass")
 }
 
-func TestAssertRoute53RecordExistsInHostedZone_Found(t *testing.T) {
+func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -91,12 +91,12 @@ func TestAssertRoute53RecordExistsInHostedZone_Found(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
 
-	assert.False(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to pass")
+	assert.False(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to pass")
 }
 
-func TestAssertRoute53RecordExistsInHostedZone_RecordNotFound(t *testing.T) {
+func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -115,12 +115,12 @@ func TestAssertRoute53RecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRoute53RecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.T) {
+func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -139,12 +139,12 @@ func TestAssertRoute53RecordExistsInHostedZone_ListResourceRecordSets_Error(t *t
 		listResourceRecordSetsErr: errors.New("some error"),
 	}
 
-	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRoute53RecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
+func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -163,12 +163,12 @@ func TestAssertRoute53RecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRoute53RecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *testing.T) {
+func TestAssertRecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -191,7 +191,7 @@ func TestAssertRoute53RecordExistsInHostedZone_ListHostedZonesByNameInput_Error(
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRoute53RecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53RecordExistsInZone to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -24,7 +25,7 @@ func (c Route53ClientMock) ListHostedZonesByNameInput(input *route53.ListHostedZ
 	return c.listHostedZonesOutput, c.listHostedZonesErr
 }
 
-func (c Route53ClientMock) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+func (c Route53ClientMock) ListResourceRecordSets(ctx context.Context, input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
 	return c.listResourceRecordSetsOutput, c.listResourceRecordSetsErr
 }
 
@@ -91,7 +92,7 @@ func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
 
 	assert.False(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to pass")
 }
@@ -115,7 +116,7 @@ func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -139,7 +140,7 @@ func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.
 		listResourceRecordSetsErr: errors.New("some error"),
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -163,7 +164,7 @@ func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
@@ -191,7 +192,7 @@ func TestAssertRecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *test
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, client, recordName, zoneName)
+	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, recordName, zoneName)
 
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }


### PR DESCRIPTION
### SUMMARY

This seeks to add a convenience function for testing
that a given record set correctly exists within the
expected hosted zone.

### DEVELOPER IMPACT

This adds a new `AssertRoute53RecordExistsInHostedZone` function (does it correctly conform to the expected signature, naming, and behavior of `infratest`? Is the function name too verbose?)

### Contribution Checklist
* [x] All changes have been reflected in comparable unit test changes or additions.
* [x] Any interactions with third party clients are done via interface types rather than direct interactions.
* [x] All new functions follow the required naming standard. (I _believe_?)
* [x] All new functions follow the required signature standards. (I _believe_?)