### PR TITLE
(MINOR) improve R53 `AssertHostedZoneExists` func

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ enable testing across technologies such as:
   * EC2
   * IAM
   * RDS
+  * Route53
   * S3
   * DynamoDB
 * Databases such as:

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -20,9 +20,9 @@ type Route53Client interface {
 	ListResourceRecordSets(context.Context, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 }
 
-// AssertRoute53HostedZoneExists asserts whether or not the Route53 zone name
+// AssertHostedZoneExists asserts whether or not the Route53 zone name
 // it's passed is found amongst those reported by the AWS API.
-func AssertRoute53HostedZoneExists(t *testing.T, client Route53Client, zoneName string) {
+func AssertHostedZoneExists(t *testing.T, client Route53Client, zoneName string) {
 	_, found, err := findZoneE(client, zoneName)
 
 	assert.Nil(t, err)

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -20,9 +20,9 @@ type Route53Client interface {
 	ListResourceRecordSets(context.Context, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 }
 
-// AssertHostedZoneExists asserts whether or not the Route53 zone name
+// AssertRoute53HostedZoneExists asserts whether or not the Route53 zone name
 // it's passed is found amongst those reported by the AWS API.
-func AssertHostedZoneExists(t *testing.T, ctx context.Context, client Route53Client, zoneName string) {
+func AssertRoute53HostedZoneExists(t *testing.T, ctx context.Context, client Route53Client, zoneName string) {
 	_, found, err := findZoneE(ctx, client, zoneName)
 
 	assert.Nil(t, err)
@@ -41,10 +41,10 @@ type AssertRecordInput struct {
 	ZoneName string
 }
 
-// AssertRecordExistsInHostedZone asserts whether or not the Route53 record
+// AssertRoute53RecordExistsInHostedZone asserts whether or not the Route53 record
 // name it's passed exists amongst those associated with the the Route53 zone whose
 // name it's passed.
-func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Route53Client, recordInput AssertRecordInput) {
+func AssertRoute53RecordExistsInHostedZone(t *testing.T, ctx context.Context, client Route53Client, recordInput AssertRecordInput) {
 	recordFound := false
 	zoneName := recordInput.ZoneName
 	recordName := recordInput.RecordName

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -16,14 +16,14 @@ import (
 // Route53Client is an AWS Route53 API client.
 // Typically, it's a [Route53](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/route53#Client).
 type Route53Client interface {
-	ListHostedZonesByNameInput(*route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error)
+	ListHostedZonesByName(context.Context, *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error)
 	ListResourceRecordSets(context.Context, *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 }
 
 // AssertHostedZoneExists asserts whether or not the Route53 zone name
 // it's passed is found amongst those reported by the AWS API.
-func AssertHostedZoneExists(t *testing.T, client Route53Client, zoneName string) {
-	_, found, err := findZoneE(client, zoneName)
+func AssertHostedZoneExists(t *testing.T, ctx context.Context, client Route53Client, zoneName string) {
+	_, found, err := findZoneE(ctx, client, zoneName)
 
 	assert.Nil(t, err)
 	assert.True(t, found, fmt.Sprintf("'%s' not found", zoneName))
@@ -49,7 +49,7 @@ func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Ro
 	zoneName := recordInput.ZoneName
 	recordName := recordInput.RecordName
 
-	z, zoneFound, err := findZoneE(client, zoneName)
+	z, zoneFound, err := findZoneE(ctx, client, zoneName)
 
 	assert.Nil(t, err)
 	assert.True(t, zoneFound, fmt.Sprintf("zone '%s' not found", zoneName))
@@ -74,8 +74,8 @@ func AssertRecordExistsInHostedZone(t *testing.T, ctx context.Context, client Ro
 	assert.True(t, recordFound, fmt.Sprintf("record '%s' not found", recordName))
 }
 
-func findZoneE(client Route53Client, zoneName string) (*types.HostedZone, bool, error) {
-	zones, err := client.ListHostedZonesByNameInput(&route53.ListHostedZonesByNameInput{
+func findZoneE(ctx context.Context, client Route53Client, zoneName string) (*types.HostedZone, bool, error) {
+	zones, err := client.ListHostedZonesByName(ctx, &route53.ListHostedZonesByNameInput{
 		DNSName: &zoneName,
 	})
 	if err != nil {

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -29,29 +29,29 @@ func (c Route53ClientMock) ListResourceRecordSets(ctx context.Context, input *ro
 	return c.listResourceRecordSetsOutput, c.listResourceRecordSetsErr
 }
 
-func TestAssertHostedZoneExists_NotFound(t *testing.T) {
+func TestAssertRoute53HostedZoneExists_NotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	client := Route53ClientMock{
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    nil,
 	}
-	AssertHostedZoneExists(fakeTest, context.Background(), client, "bar.com")
+	AssertRoute53HostedZoneExists(fakeTest, context.Background(), client, "bar.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
 
-func TestAssertHostedZoneExists_Error(t *testing.T) {
+func TestAssertRoute53HostedZoneExists_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	client := Route53ClientMock{
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    errors.New("some error"),
 	}
-	AssertHostedZoneExists(fakeTest, context.Background(), client, "foo.com")
+	AssertRoute53HostedZoneExists(fakeTest, context.Background(), client, "foo.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
 
-func TestAssertHostedZoneExists_Found(t *testing.T) {
+func TestAssertRoute53HostedZoneExists_Found(t *testing.T) {
 	fakeTest := &testing.T{}
 	name := "foo.com"
 	client := Route53ClientMock{
@@ -64,12 +64,12 @@ func TestAssertHostedZoneExists_Found(t *testing.T) {
 		},
 		listHostedZonesErr: nil,
 	}
-	AssertHostedZoneExists(fakeTest, context.Background(), client, name)
+	AssertRoute53HostedZoneExists(fakeTest, context.Background(), client, name)
 
 	assert.False(t, fakeTest.Failed(), "expected AssertHostedZoneExists to pass")
 }
 
-func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_Found(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -92,7 +92,7 @@ func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		ZoneName:   zoneName,
 	})
@@ -100,7 +100,7 @@ func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {
 	assert.False(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to pass")
 }
 
-func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -119,7 +119,7 @@ func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		ZoneName:   zoneName,
 	})
@@ -127,7 +127,7 @@ func TestAssertRecordExistsInHostedZone_RecordNotFound(t *testing.T) {
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRecordExistsInHostedZone_RecordTypeNotFound(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_RecordTypeNotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -151,7 +151,7 @@ func TestAssertRecordExistsInHostedZone_RecordTypeNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		RecordType: types.RRTypeSoa,
 		ZoneName:   zoneName,
@@ -160,7 +160,7 @@ func TestAssertRecordExistsInHostedZone_RecordTypeNotFound(t *testing.T) {
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -179,7 +179,7 @@ func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.
 		listResourceRecordSetsErr: errors.New("some error"),
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		ZoneName:   zoneName,
 	})
@@ -187,7 +187,7 @@ func TestAssertRecordExistsInHostedZone_ListResourceRecordSets_Error(t *testing.
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -206,7 +206,7 @@ func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		ZoneName:   zoneName,
 	})
@@ -214,7 +214,7 @@ func TestAssertRecordExistsInHostedZone_ZoneNotFound(t *testing.T) {
 	assert.True(t, fakeTest.Failed(), "expected AssertRecordExistsInZone to fail")
 }
 
-func TestAssertRecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *testing.T) {
+func TestAssertRoute53RecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	zoneName := "foo.com"
 	recordName := fmt.Sprintf("foo.%s", zoneName)
@@ -237,7 +237,7 @@ func TestAssertRecordExistsInHostedZone_ListHostedZonesByNameInput_Error(t *test
 		listResourceRecordSetsErr: nil,
 	}
 
-	AssertRecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
+	AssertRoute53RecordExistsInHostedZone(fakeTest, context.Background(), client, AssertRecordInput{
 		RecordName: recordName,
 		ZoneName:   zoneName,
 	})

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -21,7 +21,7 @@ type Route53ClientMock struct {
 	listResourceRecordSetsErr    error
 }
 
-func (c Route53ClientMock) ListHostedZonesByNameInput(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error) {
+func (c Route53ClientMock) ListHostedZonesByName(ctx context.Context, input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesOutput, error) {
 	return c.listHostedZonesOutput, c.listHostedZonesErr
 }
 
@@ -35,7 +35,7 @@ func TestAssertHostedZoneExists_NotFound(t *testing.T) {
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    nil,
 	}
-	AssertHostedZoneExists(fakeTest, client, "bar.com")
+	AssertHostedZoneExists(fakeTest, context.Background(), client, "bar.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
@@ -46,7 +46,7 @@ func TestAssertHostedZoneExists_Error(t *testing.T) {
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    errors.New("some error"),
 	}
-	AssertHostedZoneExists(fakeTest, client, "foo.com")
+	AssertHostedZoneExists(fakeTest, context.Background(), client, "foo.com")
 
 	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
@@ -64,7 +64,7 @@ func TestAssertHostedZoneExists_Found(t *testing.T) {
 		},
 		listHostedZonesErr: nil,
 	}
-	AssertHostedZoneExists(fakeTest, client, name)
+	AssertHostedZoneExists(fakeTest, context.Background(), client, name)
 
 	assert.False(t, fakeTest.Failed(), "expected AssertHostedZoneExists to pass")
 }

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -29,29 +29,29 @@ func (c Route53ClientMock) ListResourceRecordSets(ctx context.Context, input *ro
 	return c.listResourceRecordSetsOutput, c.listResourceRecordSetsErr
 }
 
-func TestAssertRoute53HostedZoneExists_NotFound(t *testing.T) {
+func TestAssertHostedZoneExists_NotFound(t *testing.T) {
 	fakeTest := &testing.T{}
 	client := Route53ClientMock{
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    nil,
 	}
-	AssertRoute53HostedZoneExists(fakeTest, client, "bar.com")
+	AssertHostedZoneExists(fakeTest, client, "bar.com")
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
 
-func TestAssertRoute53HostedZoneExists_Error(t *testing.T) {
+func TestAssertHostedZoneExists_Error(t *testing.T) {
 	fakeTest := &testing.T{}
 	client := Route53ClientMock{
 		listHostedZonesOutput: &route53.ListHostedZonesOutput{},
 		listHostedZonesErr:    errors.New("some error"),
 	}
-	AssertRoute53HostedZoneExists(fakeTest, client, "foo.com")
+	AssertHostedZoneExists(fakeTest, client, "foo.com")
 
-	assert.True(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to fail")
+	assert.True(t, fakeTest.Failed(), "expected AssertHostedZoneExists to fail")
 }
 
-func TestAssertRoute53HostedZoneExists_Found(t *testing.T) {
+func TestAssertHostedZoneExists_Found(t *testing.T) {
 	fakeTest := &testing.T{}
 	name := "foo.com"
 	client := Route53ClientMock{
@@ -64,9 +64,9 @@ func TestAssertRoute53HostedZoneExists_Found(t *testing.T) {
 		},
 		listHostedZonesErr: nil,
 	}
-	AssertRoute53HostedZoneExists(fakeTest, client, name)
+	AssertHostedZoneExists(fakeTest, client, name)
 
-	assert.False(t, fakeTest.Failed(), "expected AssertRoute53HostedZoneExists to pass")
+	assert.False(t, fakeTest.Failed(), "expected AssertHostedZoneExists to pass")
 }
 
 func TestAssertRecordExistsInHostedZone_Found(t *testing.T) {


### PR DESCRIPTION
### SUMMARY
* fixes issue #19 
* ~While this does change the method name from `AssertRoute53HostedZoneExists` to `AssertHostedZoneExists` -- and therefore, in theory, introduces a breaking change -- I don't believe the original `AssertRoute53HostedZoneExists` was functioning properly due to issue #19 ~

### DEVELOPER IMPACT

While this does change the method name from `AssertRoute53HostedZoneExists` to `AssertHostedZoneExists` -- and therefore, in theory, introduces a breaking change -- I don't believe the original `AssertRoute53HostedZoneExists` was functioning properly due to issue #19 

### Contribution Checklist
* [X] All changes have been reflected in comparable unit test changes or additions.
* [X] Any interactions with third party clients are done via interface types rather than direct interactions.
* [X] All new functions follow the required naming standard.
* [X] All new functions follow the required signature standards.

### Discussion question

This PR changes the func name from `AssertRoute53HostedZoneExists` to `AssertHostedZoneExists`, as per [PR 15 discussion](https://github.com/HBOCodeLabs/infratest/pull/15#discussion_r756090458):

>  I think this would be better named as `AssertRecordExistsInHostedZone`, since route53 is already part of the package name. 

However, I believe ☝️ is not quite correct. `route53` is _not_ actually part of the package name, if I understand correctly. The package name is `aws`. So, should the func names include `*Route53*` or not? As a frame of reference, the EC2-related funcs _do_ appear to include `*EC2*` in their names: https://github.com/HBOCodeLabs/infratest/blob/main/pkg/aws/ec2.go#L57

**Update**: I've changed both Route53 assertion functions to include `*Route53*` in their name, as is consistent with the other `infratest` functions.