### PR TITLE
Ensuring tests run for the correct device id

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -141,13 +141,16 @@ func AssertEC2VolumeType(t *testing.T, ctx context.Context, client EC2Client, in
 	instance, err := getEC2InstanceByInstanceIDE(ctx, client, input.InstanceID)
 
 	require.NoError(t, err)
+	deviceFound := false
 
 	for _, v := range instance.BlockDeviceMappings {
 		if *v.DeviceName == input.DeviceID {
+			deviceFound = true
 			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
 			require.NoError(t, err)
 			volumeType := fmt.Sprintf("%v", volume.VolumeType)
 			assert.Equal(t, input.VolumeType, volumeType, "Volume with device ID '%s' does not have the right volume type.", input.DeviceID)
+			assert.True(t, deviceFound, "Volume with device ID '%s' was not found for instance '%s'.", input.DeviceID, input.InstanceID)
 		}
 	}
 }
@@ -158,8 +161,11 @@ func AssertEC2VolumeThroughput(t *testing.T, ctx context.Context, client EC2Clie
 	instance, err := getEC2InstanceByInstanceIDE(ctx, client, input.InstanceID)
 	require.NoError(t, err)
 
+	deviceFound := false
+
 	for _, v := range instance.BlockDeviceMappings {
 		if *v.DeviceName == input.DeviceID {
+			deviceFound = true
 			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
 			require.NoError(t, err)
 			if input.VolumeType != "gp2" {
@@ -167,6 +173,7 @@ func AssertEC2VolumeThroughput(t *testing.T, ctx context.Context, client EC2Clie
 			} else {
 				t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
 			}
+			assert.True(t, deviceFound, "Volume with device ID '%s' was not found for instance '%s'.", input.DeviceID, input.InstanceID)
 		}
 	}
 }
@@ -176,16 +183,18 @@ func AssertEC2VolumeIOPS(t *testing.T, ctx context.Context, client EC2Client, in
 
 	instance, err := getEC2InstanceByInstanceIDE(ctx, client, input.InstanceID)
 	require.NoError(t, err)
-
+	deviceFound := false
 	for _, v := range instance.BlockDeviceMappings {
 		if *v.DeviceName == input.DeviceID {
 			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
 			require.NoError(t, err)
+			deviceFound = true
 			if input.VolumeType != "gp2" {
 				assert.Equal(t, input.VolumeIOPS, volume.Iops, "Volume with device ID '%s' does not have the right IOPS value associated to volume.", input.DeviceID)
 			} else {
 				t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
 			}
+			assert.True(t, deviceFound, "Volume with device ID '%s' was not found for instance '%s'.", input.DeviceID, input.InstanceID)
 		}
 	}
 }

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -143,10 +143,12 @@ func AssertEC2VolumeType(t *testing.T, ctx context.Context, client EC2Client, in
 	require.NoError(t, err)
 
 	for _, v := range instance.BlockDeviceMappings {
-		volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
-		require.NoError(t, err)
-		volumeType := fmt.Sprintf("%v", volume.VolumeType)
-		assert.Equal(t, input.VolumeType, volumeType, "Volume with device ID '%s' does not have the right volume type.", input.DeviceID)
+		if *v.DeviceName == input.DeviceID {
+			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
+			require.NoError(t, err)
+			volumeType := fmt.Sprintf("%v", volume.VolumeType)
+			assert.Equal(t, input.VolumeType, volumeType, "Volume with device ID '%s' does not have the right volume type.", input.DeviceID)
+		}
 	}
 }
 
@@ -157,12 +159,14 @@ func AssertEC2VolumeThroughput(t *testing.T, ctx context.Context, client EC2Clie
 	require.NoError(t, err)
 
 	for _, v := range instance.BlockDeviceMappings {
-		volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
-		require.NoError(t, err)
-		if input.VolumeType != "gp2" {
-			assert.Equal(t, input.VolumeThroughput, volume.Throughput, "Volume with device ID '%s' does not have the right throughput associated to volume.", input.DeviceID)
-		} else {
-			t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
+		if *v.DeviceName == input.DeviceID {
+			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
+			require.NoError(t, err)
+			if input.VolumeType != "gp2" {
+				assert.Equal(t, input.VolumeThroughput, volume.Throughput, "Volume with device ID '%s' does not have the right throughput associated to volume.", input.DeviceID)
+			} else {
+				t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
+			}
 		}
 	}
 }
@@ -174,12 +178,14 @@ func AssertEC2VolumeIOPS(t *testing.T, ctx context.Context, client EC2Client, in
 	require.NoError(t, err)
 
 	for _, v := range instance.BlockDeviceMappings {
-		volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
-		require.NoError(t, err)
-		if input.VolumeType != "gp2" {
-			assert.Equal(t, input.VolumeIOPS, volume.Iops, "Volume with device ID '%s' does not have the right IOPS value associated to volume.", input.DeviceID)
-		} else {
-			t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
+		if *v.DeviceName == input.DeviceID {
+			volume, err := getEC2VolumeByVolumeIDE(ctx, client, *v.Ebs.VolumeId)
+			require.NoError(t, err)
+			if input.VolumeType != "gp2" {
+				assert.Equal(t, input.VolumeIOPS, volume.Iops, "Volume with device ID '%s' does not have the right IOPS value associated to volume.", input.DeviceID)
+			} else {
+				t.Logf("This test is ignored since it is not gp3 volume type : %s", input.VolumeType)
+			}
 		}
 	}
 }

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -789,6 +789,67 @@ func TestAssertEC2VolumeType_MatchWithGP2(t *testing.T) {
 	assert.False(t, fakeTest.Failed())
 }
 
+func TestAssertEC2VolumeType_MatchWithGP2MultipleDevices(t *testing.T) {
+	// Setup
+	instanceID := "i546acas321sd"
+	volumeId := "v123dfasd92"
+	deviceNames := []string{
+		"/dev/sdc",
+		"/dev/sdd",
+	}
+	kmsKeyID := "/key/id"
+	encrypted := true
+	volumeType := types.VolumeTypeGp2
+	volumeIops := aws.Int32(0)
+	volumeThroughput := aws.Int32(0)
+	for _, deviceName := range deviceNames {
+		instanceOutput := &ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation{
+				{
+					Instances: []types.Instance{
+						{
+							InstanceId: &instanceID,
+							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+								{
+									DeviceName: &deviceName,
+									Ebs: &types.EbsInstanceBlockDevice{
+										VolumeId: &volumeId,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		volumeOutput := &ec2.DescribeVolumesOutput{
+			Volumes: []types.Volume{
+				{
+					Encrypted:  &encrypted,
+					KmsKeyId:   &kmsKeyID,
+					VolumeType: volumeType,
+				},
+			},
+		}
+		clientMock := &EC2ClientMock{
+			DescribeInstancesOutput: instanceOutput,
+			DescribeVolumesOutput:   volumeOutput,
+		}
+		fakeTest := &testing.T{}
+
+		// Execute
+		AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+			DeviceID:         deviceName,
+			InstanceID:       instanceID,
+			VolumeType:       "gp2",
+			VolumeIOPS:       volumeIops,
+			VolumeThroughput: volumeThroughput,
+		})
+
+		// Assert
+		assert.False(t, fakeTest.Failed())
+	}
+}
 func TestAssertEC2VolumeType_MatchWithGP3(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
@@ -846,6 +907,67 @@ func TestAssertEC2VolumeType_MatchWithGP3(t *testing.T) {
 	assert.False(t, fakeTest.Failed())
 }
 
+func TestAssertEC2VolumeType_MatchWithGP3MultipleDevices(t *testing.T) {
+	// Setup
+	instanceID := "i546acas321sd"
+	volumeId := "v123dfasd92"
+	deviceNames := []string{
+		"/dev/sdc",
+		"/dev/sdd",
+	}
+	kmsKeyID := "/key/id"
+	encrypted := true
+	volumeType := types.VolumeTypeGp3
+	volumeIops := aws.Int32(100)
+	volumeThroughput := aws.Int32(1000)
+	for _, deviceName := range deviceNames {
+		instanceOutput := &ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation{
+				{
+					Instances: []types.Instance{
+						{
+							InstanceId: &instanceID,
+							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+								{
+									DeviceName: &deviceName,
+									Ebs: &types.EbsInstanceBlockDevice{
+										VolumeId: &volumeId,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		volumeOutput := &ec2.DescribeVolumesOutput{
+			Volumes: []types.Volume{
+				{
+					Encrypted:  &encrypted,
+					KmsKeyId:   &kmsKeyID,
+					VolumeType: volumeType,
+				},
+			},
+		}
+		clientMock := &EC2ClientMock{
+			DescribeInstancesOutput: instanceOutput,
+			DescribeVolumesOutput:   volumeOutput,
+		}
+		fakeTest := &testing.T{}
+
+		// Execute
+		AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+			DeviceID:         deviceName,
+			InstanceID:       instanceID,
+			VolumeType:       "gp3",
+			VolumeIOPS:       volumeIops,
+			VolumeThroughput: volumeThroughput,
+		})
+
+		// Assert
+		assert.False(t, fakeTest.Failed())
+	}
+}
 func TestAssertEC2VolumeType_MatchWithThroughput(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
@@ -905,6 +1027,69 @@ func TestAssertEC2VolumeType_MatchWithThroughput(t *testing.T) {
 	assert.False(t, fakeTest.Failed())
 }
 
+func TestAssertEC2VolumeType_MatchWithThroughputMultipleDevices(t *testing.T) {
+	// Setup
+	instanceID := "i546acas321sd"
+	volumeId := "v123dfasd92"
+	deviceNames := []string{
+		"/dev/sdc",
+		"/dev/sdd",
+	}
+	kmsKeyID := "/key/id"
+	encrypted := true
+	volumeType := types.VolumeTypeGp3
+	volumeIops := aws.Int32(100)
+	volumeThroughput := aws.Int32(1000)
+	for _, deviceName := range deviceNames {
+		instanceOutput := &ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation{
+				{
+					Instances: []types.Instance{
+						{
+							InstanceId: &instanceID,
+							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+								{
+									DeviceName: &deviceName,
+									Ebs: &types.EbsInstanceBlockDevice{
+										VolumeId: &volumeId,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		volumeOutput := &ec2.DescribeVolumesOutput{
+			Volumes: []types.Volume{
+				{
+					Encrypted:  &encrypted,
+					KmsKeyId:   &kmsKeyID,
+					VolumeType: volumeType,
+					Throughput: volumeThroughput,
+					Iops:       volumeIops,
+				},
+			},
+		}
+		clientMock := &EC2ClientMock{
+			DescribeInstancesOutput: instanceOutput,
+			DescribeVolumesOutput:   volumeOutput,
+		}
+		fakeTest := &testing.T{}
+
+		// Execute
+		AssertEC2VolumeThroughput(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+			DeviceID:         deviceName,
+			InstanceID:       instanceID,
+			VolumeType:       "gp3",
+			VolumeIOPS:       volumeIops,
+			VolumeThroughput: volumeThroughput,
+		})
+
+		// Assert
+		assert.False(t, fakeTest.Failed())
+	}
+}
 func TestAssertEC2VolumeType_MatchWithIOPS(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
@@ -962,4 +1147,67 @@ func TestAssertEC2VolumeType_MatchWithIOPS(t *testing.T) {
 
 	// Assert
 	assert.False(t, fakeTest.Failed())
+}
+
+func TestAssertEC2VolumeType_MatchWithIOPSMultipleDevices(t *testing.T) {
+	// Setup
+	instanceID := "i546acas321sd"
+	volumeId := "v123dfasd92"
+	deviceNames := []string{
+		"/dev/sdc",
+		"/dev/sdd",
+	}
+	kmsKeyID := "/key/id"
+	encrypted := true
+	volumeType := types.VolumeTypeGp3
+	volumeIops := aws.Int32(100)
+	volumeThroughput := aws.Int32(1000)
+	for _, deviceName := range deviceNames {
+		instanceOutput := &ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation{
+				{
+					Instances: []types.Instance{
+						{
+							InstanceId: &instanceID,
+							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+								{
+									DeviceName: &deviceName,
+									Ebs: &types.EbsInstanceBlockDevice{
+										VolumeId: &volumeId,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		volumeOutput := &ec2.DescribeVolumesOutput{
+			Volumes: []types.Volume{
+				{
+					Encrypted:  &encrypted,
+					KmsKeyId:   &kmsKeyID,
+					VolumeType: volumeType,
+					Throughput: volumeThroughput,
+					Iops:       volumeIops,
+				},
+			},
+		}
+		clientMock := &EC2ClientMock{
+			DescribeInstancesOutput: instanceOutput,
+			DescribeVolumesOutput:   volumeOutput,
+		}
+		fakeTest := &testing.T{}
+
+		// Execute
+		AssertEC2VolumeIOPS(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+			DeviceID:         deviceName,
+			InstanceID:       instanceID,
+			VolumeType:       "gp3",
+			VolumeIOPS:       volumeIops,
+			VolumeThroughput: volumeThroughput,
+		})
+		// Assert
+		assert.False(t, fakeTest.Failed())
+	}
 }

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -736,249 +736,257 @@ func TestAssertEC2VolumeType_MatchWithGP2MultipleDevices(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
 	volumeId := "v123dfasd92"
-	deviceNames := []string{
-		"/dev/sdc",
-		"/dev/sdd",
-	}
+	deviceName := "/dev/sdc"
+	excludedDeviceName := "/dev/sdd"
 	kmsKeyID := "/key/id"
 	encrypted := true
 	volumeType := types.VolumeTypeGp2
 	volumeIops := aws.Int32(0)
 	volumeThroughput := aws.Int32(0)
-	for _, deviceName := range deviceNames {
-		instanceOutput := &ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation{
-				{
-					Instances: []types.Instance{
-						{
-							InstanceId: &instanceID,
-							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-								{
-									DeviceName: &deviceName,
-									Ebs: &types.EbsInstanceBlockDevice{
-										VolumeId: &volumeId,
-									},
+	instanceOutput := &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						InstanceId: &instanceID,
+						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+							{
+								DeviceName: &deviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
+								},
+							},
+							{
+								DeviceName: &excludedDeviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
 								},
 							},
 						},
 					},
 				},
 			},
-		}
-		volumeOutput := &ec2.DescribeVolumesOutput{
-			Volumes: []types.Volume{
-				{
-					Encrypted:  &encrypted,
-					KmsKeyId:   &kmsKeyID,
-					VolumeType: volumeType,
-				},
-			},
-		}
-		clientMock := &EC2ClientMock{
-			DescribeInstancesOutput: instanceOutput,
-			DescribeVolumesOutput:   volumeOutput,
-		}
-		fakeTest := &testing.T{}
-
-		// Execute
-		AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-			DeviceID:         deviceName,
-			InstanceID:       instanceID,
-			VolumeType:       "gp2",
-			VolumeIOPS:       volumeIops,
-			VolumeThroughput: volumeThroughput,
-		})
-
-		// Assert
-		assert.False(t, fakeTest.Failed())
+		},
 	}
+	volumeOutput := &ec2.DescribeVolumesOutput{
+		Volumes: []types.Volume{
+			{
+				Encrypted:  &encrypted,
+				KmsKeyId:   &kmsKeyID,
+				VolumeType: volumeType,
+			},
+		},
+	}
+	clientMock := &EC2ClientMock{
+		DescribeInstancesOutput: instanceOutput,
+		DescribeVolumesOutput:   volumeOutput,
+	}
+	fakeTest := &testing.T{}
+
+	// Execute
+	AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+		DeviceID:         deviceName,
+		InstanceID:       instanceID,
+		VolumeType:       "gp2",
+		VolumeIOPS:       volumeIops,
+		VolumeThroughput: volumeThroughput,
+	})
+
+	// Assert
+	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithGP3MultipleDevices(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
 	volumeId := "v123dfasd92"
-	deviceNames := []string{
-		"/dev/sdc",
-		"/dev/sdd",
-	}
+	deviceName := "/dev/sdc"
+	excludedDeviceName := "/dev/sdd"
 	kmsKeyID := "/key/id"
 	encrypted := true
 	volumeType := types.VolumeTypeGp3
 	volumeIops := aws.Int32(100)
 	volumeThroughput := aws.Int32(1000)
-	for _, deviceName := range deviceNames {
-		instanceOutput := &ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation{
-				{
-					Instances: []types.Instance{
-						{
-							InstanceId: &instanceID,
-							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-								{
-									DeviceName: &deviceName,
-									Ebs: &types.EbsInstanceBlockDevice{
-										VolumeId: &volumeId,
-									},
+	instanceOutput := &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						InstanceId: &instanceID,
+						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+							{
+								DeviceName: &deviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
+								},
+							},
+							{
+								DeviceName: &excludedDeviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
 								},
 							},
 						},
 					},
 				},
 			},
-		}
-		volumeOutput := &ec2.DescribeVolumesOutput{
-			Volumes: []types.Volume{
-				{
-					Encrypted:  &encrypted,
-					KmsKeyId:   &kmsKeyID,
-					VolumeType: volumeType,
-				},
-			},
-		}
-		clientMock := &EC2ClientMock{
-			DescribeInstancesOutput: instanceOutput,
-			DescribeVolumesOutput:   volumeOutput,
-		}
-		fakeTest := &testing.T{}
-
-		// Execute
-		AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-			DeviceID:         deviceName,
-			InstanceID:       instanceID,
-			VolumeType:       "gp3",
-			VolumeIOPS:       volumeIops,
-			VolumeThroughput: volumeThroughput,
-		})
-
-		// Assert
-		assert.False(t, fakeTest.Failed())
+		},
 	}
+	volumeOutput := &ec2.DescribeVolumesOutput{
+		Volumes: []types.Volume{
+			{
+				Encrypted:  &encrypted,
+				KmsKeyId:   &kmsKeyID,
+				VolumeType: volumeType,
+			},
+		},
+	}
+	clientMock := &EC2ClientMock{
+		DescribeInstancesOutput: instanceOutput,
+		DescribeVolumesOutput:   volumeOutput,
+	}
+	fakeTest := &testing.T{}
+
+	// Execute
+	AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+		DeviceID:         deviceName,
+		InstanceID:       instanceID,
+		VolumeType:       "gp3",
+		VolumeIOPS:       volumeIops,
+		VolumeThroughput: volumeThroughput,
+	})
+
+	// Assert
+	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithThroughputMultipleDevices(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
 	volumeId := "v123dfasd92"
-	deviceNames := []string{
-		"/dev/sdc",
-		"/dev/sdd",
-	}
+	deviceName := "/dev/sdc"
+	excludedDeviceName := "/dev/sdd"
 	kmsKeyID := "/key/id"
 	encrypted := true
 	volumeType := types.VolumeTypeGp3
 	volumeIops := aws.Int32(100)
 	volumeThroughput := aws.Int32(1000)
-	for _, deviceName := range deviceNames {
-		instanceOutput := &ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation{
-				{
-					Instances: []types.Instance{
-						{
-							InstanceId: &instanceID,
-							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-								{
-									DeviceName: &deviceName,
-									Ebs: &types.EbsInstanceBlockDevice{
-										VolumeId: &volumeId,
-									},
+	instanceOutput := &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						InstanceId: &instanceID,
+						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+							{
+								DeviceName: &deviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
+								},
+							},
+							{
+								DeviceName: &excludedDeviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
 								},
 							},
 						},
 					},
 				},
 			},
-		}
-		volumeOutput := &ec2.DescribeVolumesOutput{
-			Volumes: []types.Volume{
-				{
-					Encrypted:  &encrypted,
-					KmsKeyId:   &kmsKeyID,
-					VolumeType: volumeType,
-					Throughput: volumeThroughput,
-					Iops:       volumeIops,
-				},
-			},
-		}
-		clientMock := &EC2ClientMock{
-			DescribeInstancesOutput: instanceOutput,
-			DescribeVolumesOutput:   volumeOutput,
-		}
-		fakeTest := &testing.T{}
-
-		// Execute
-		AssertEC2VolumeThroughput(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-			DeviceID:         deviceName,
-			InstanceID:       instanceID,
-			VolumeType:       "gp3",
-			VolumeIOPS:       volumeIops,
-			VolumeThroughput: volumeThroughput,
-		})
-
-		// Assert
-		assert.False(t, fakeTest.Failed())
+		},
 	}
+	volumeOutput := &ec2.DescribeVolumesOutput{
+		Volumes: []types.Volume{
+			{
+				Encrypted:  &encrypted,
+				KmsKeyId:   &kmsKeyID,
+				VolumeType: volumeType,
+				Throughput: volumeThroughput,
+				Iops:       volumeIops,
+			},
+		},
+	}
+	clientMock := &EC2ClientMock{
+		DescribeInstancesOutput: instanceOutput,
+		DescribeVolumesOutput:   volumeOutput,
+	}
+	fakeTest := &testing.T{}
+
+	// Execute
+	AssertEC2VolumeThroughput(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+		DeviceID:         deviceName,
+		InstanceID:       instanceID,
+		VolumeType:       "gp3",
+		VolumeIOPS:       volumeIops,
+		VolumeThroughput: volumeThroughput,
+	})
+
+	// Assert
+	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithIOPSMultipleDevices(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
 	volumeId := "v123dfasd92"
-	deviceNames := []string{
-		"/dev/sdc",
-		"/dev/sdd",
-	}
+	deviceName := "/dev/sdc"
+	excludedDeviceName := "/dev/sdd"
 	kmsKeyID := "/key/id"
 	encrypted := true
 	volumeType := types.VolumeTypeGp3
 	volumeIops := aws.Int32(100)
 	volumeThroughput := aws.Int32(1000)
-	for _, deviceName := range deviceNames {
-		instanceOutput := &ec2.DescribeInstancesOutput{
-			Reservations: []types.Reservation{
-				{
-					Instances: []types.Instance{
-						{
-							InstanceId: &instanceID,
-							BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-								{
-									DeviceName: &deviceName,
-									Ebs: &types.EbsInstanceBlockDevice{
-										VolumeId: &volumeId,
-									},
+	instanceOutput := &ec2.DescribeInstancesOutput{
+		Reservations: []types.Reservation{
+			{
+				Instances: []types.Instance{
+					{
+						InstanceId: &instanceID,
+						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+							{
+								DeviceName: &deviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
+								},
+							},
+							{
+								DeviceName: &excludedDeviceName,
+								Ebs: &types.EbsInstanceBlockDevice{
+									VolumeId: &volumeId,
 								},
 							},
 						},
 					},
 				},
 			},
-		}
-		volumeOutput := &ec2.DescribeVolumesOutput{
-			Volumes: []types.Volume{
-				{
-					Encrypted:  &encrypted,
-					KmsKeyId:   &kmsKeyID,
-					VolumeType: volumeType,
-					Throughput: volumeThroughput,
-					Iops:       volumeIops,
-				},
-			},
-		}
-		clientMock := &EC2ClientMock{
-			DescribeInstancesOutput: instanceOutput,
-			DescribeVolumesOutput:   volumeOutput,
-		}
-		fakeTest := &testing.T{}
-
-		// Execute
-		AssertEC2VolumeIOPS(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-			DeviceID:         deviceName,
-			InstanceID:       instanceID,
-			VolumeType:       "gp3",
-			VolumeIOPS:       volumeIops,
-			VolumeThroughput: volumeThroughput,
-		})
-		// Assert
-		assert.False(t, fakeTest.Failed())
+		},
 	}
+	volumeOutput := &ec2.DescribeVolumesOutput{
+		Volumes: []types.Volume{
+			{
+				Encrypted:  &encrypted,
+				KmsKeyId:   &kmsKeyID,
+				VolumeType: volumeType,
+				Throughput: volumeThroughput,
+				Iops:       volumeIops,
+			},
+		},
+	}
+	clientMock := &EC2ClientMock{
+		DescribeInstancesOutput: instanceOutput,
+		DescribeVolumesOutput:   volumeOutput,
+	}
+	fakeTest := &testing.T{}
+
+	// Execute
+	AssertEC2VolumeIOPS(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
+		DeviceID:         deviceName,
+		InstanceID:       instanceID,
+		VolumeType:       "gp3",
+		VolumeIOPS:       volumeIops,
+		VolumeThroughput: volumeThroughput,
+	})
+	// Assert
+	assert.False(t, fakeTest.Failed())
 }

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -732,63 +732,6 @@ func TestGetEC2SecurityGroupByNameE(t *testing.T) {
 	assert.Equal(t, expectedOutput, actualOutput)
 }
 
-func TestAssertEC2VolumeType_MatchWithGP2(t *testing.T) {
-	// Setup
-	instanceID := "i546acas321sd"
-	volumeId := "v123dfasd92"
-	deviceName := "/dev/sdc"
-	kmsKeyID := "/key/id"
-	encrypted := true
-	volumeType := types.VolumeTypeGp2
-	volumeIops := aws.Int32(0)
-	volumeThroughput := aws.Int32(0)
-	instanceOutput := &ec2.DescribeInstancesOutput{
-		Reservations: []types.Reservation{
-			{
-				Instances: []types.Instance{
-					{
-						InstanceId: &instanceID,
-						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-							{
-								DeviceName: &deviceName,
-								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: &volumeId,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	volumeOutput := &ec2.DescribeVolumesOutput{
-		Volumes: []types.Volume{
-			{
-				Encrypted:  &encrypted,
-				KmsKeyId:   &kmsKeyID,
-				VolumeType: volumeType,
-			},
-		},
-	}
-	clientMock := &EC2ClientMock{
-		DescribeInstancesOutput: instanceOutput,
-		DescribeVolumesOutput:   volumeOutput,
-	}
-	fakeTest := &testing.T{}
-
-	// Execute
-	AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-		DeviceID:         deviceName,
-		InstanceID:       instanceID,
-		VolumeType:       "gp2",
-		VolumeIOPS:       volumeIops,
-		VolumeThroughput: volumeThroughput,
-	})
-
-	// Assert
-	assert.False(t, fakeTest.Failed())
-}
-
 func TestAssertEC2VolumeType_MatchWithGP2MultipleDevices(t *testing.T) {
 	// Setup
 	instanceID := "i546acas321sd"
@@ -849,62 +792,6 @@ func TestAssertEC2VolumeType_MatchWithGP2MultipleDevices(t *testing.T) {
 		// Assert
 		assert.False(t, fakeTest.Failed())
 	}
-}
-func TestAssertEC2VolumeType_MatchWithGP3(t *testing.T) {
-	// Setup
-	instanceID := "i546acas321sd"
-	volumeId := "v123dfasd92"
-	deviceName := "/dev/sdc"
-	kmsKeyID := "/key/id"
-	encrypted := true
-	volumeType := types.VolumeTypeGp3
-	volumeIops := aws.Int32(100)
-	volumeThroughput := aws.Int32(1000)
-	instanceOutput := &ec2.DescribeInstancesOutput{
-		Reservations: []types.Reservation{
-			{
-				Instances: []types.Instance{
-					{
-						InstanceId: &instanceID,
-						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-							{
-								DeviceName: &deviceName,
-								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: &volumeId,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	volumeOutput := &ec2.DescribeVolumesOutput{
-		Volumes: []types.Volume{
-			{
-				Encrypted:  &encrypted,
-				KmsKeyId:   &kmsKeyID,
-				VolumeType: volumeType,
-			},
-		},
-	}
-	clientMock := &EC2ClientMock{
-		DescribeInstancesOutput: instanceOutput,
-		DescribeVolumesOutput:   volumeOutput,
-	}
-	fakeTest := &testing.T{}
-
-	// Execute
-	AssertEC2VolumeType(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-		DeviceID:         deviceName,
-		InstanceID:       instanceID,
-		VolumeType:       "gp3",
-		VolumeIOPS:       volumeIops,
-		VolumeThroughput: volumeThroughput,
-	})
-
-	// Assert
-	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithGP3MultipleDevices(t *testing.T) {
@@ -967,64 +854,6 @@ func TestAssertEC2VolumeType_MatchWithGP3MultipleDevices(t *testing.T) {
 		// Assert
 		assert.False(t, fakeTest.Failed())
 	}
-}
-func TestAssertEC2VolumeType_MatchWithThroughput(t *testing.T) {
-	// Setup
-	instanceID := "i546acas321sd"
-	volumeId := "v123dfasd92"
-	deviceName := "/dev/sdc"
-	kmsKeyID := "/key/id"
-	encrypted := true
-	volumeType := types.VolumeTypeGp3
-	volumeIops := aws.Int32(100)
-	volumeThroughput := aws.Int32(1000)
-	instanceOutput := &ec2.DescribeInstancesOutput{
-		Reservations: []types.Reservation{
-			{
-				Instances: []types.Instance{
-					{
-						InstanceId: &instanceID,
-						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-							{
-								DeviceName: &deviceName,
-								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: &volumeId,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	volumeOutput := &ec2.DescribeVolumesOutput{
-		Volumes: []types.Volume{
-			{
-				Encrypted:  &encrypted,
-				KmsKeyId:   &kmsKeyID,
-				VolumeType: volumeType,
-				Throughput: volumeThroughput,
-				Iops:       volumeIops,
-			},
-		},
-	}
-	clientMock := &EC2ClientMock{
-		DescribeInstancesOutput: instanceOutput,
-		DescribeVolumesOutput:   volumeOutput,
-	}
-	fakeTest := &testing.T{}
-
-	// Execute
-	AssertEC2VolumeThroughput(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-		DeviceID:         deviceName,
-		InstanceID:       instanceID,
-		VolumeType:       "gp3",
-		VolumeIOPS:       volumeIops,
-		VolumeThroughput: volumeThroughput,
-	})
-
-	// Assert
-	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithThroughputMultipleDevices(t *testing.T) {
@@ -1089,64 +918,6 @@ func TestAssertEC2VolumeType_MatchWithThroughputMultipleDevices(t *testing.T) {
 		// Assert
 		assert.False(t, fakeTest.Failed())
 	}
-}
-func TestAssertEC2VolumeType_MatchWithIOPS(t *testing.T) {
-	// Setup
-	instanceID := "i546acas321sd"
-	volumeId := "v123dfasd92"
-	deviceName := "/dev/sdc"
-	kmsKeyID := "/key/id"
-	encrypted := true
-	volumeType := types.VolumeTypeGp3
-	volumeIops := aws.Int32(100)
-	volumeThroughput := aws.Int32(1000)
-	instanceOutput := &ec2.DescribeInstancesOutput{
-		Reservations: []types.Reservation{
-			{
-				Instances: []types.Instance{
-					{
-						InstanceId: &instanceID,
-						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
-							{
-								DeviceName: &deviceName,
-								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: &volumeId,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	volumeOutput := &ec2.DescribeVolumesOutput{
-		Volumes: []types.Volume{
-			{
-				Encrypted:  &encrypted,
-				KmsKeyId:   &kmsKeyID,
-				VolumeType: volumeType,
-				Throughput: volumeThroughput,
-				Iops:       volumeIops,
-			},
-		},
-	}
-	clientMock := &EC2ClientMock{
-		DescribeInstancesOutput: instanceOutput,
-		DescribeVolumesOutput:   volumeOutput,
-	}
-	fakeTest := &testing.T{}
-
-	// Execute
-	AssertEC2VolumeIOPS(fakeTest, context.Background(), clientMock, AssertVolumeAttributesInput{
-		DeviceID:         deviceName,
-		InstanceID:       instanceID,
-		VolumeType:       "gp3",
-		VolumeIOPS:       volumeIops,
-		VolumeThroughput: volumeThroughput,
-	})
-
-	// Assert
-	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2VolumeType_MatchWithIOPSMultipleDevices(t *testing.T) {


### PR DESCRIPTION
### SUMMARY
* Fix to ensure tests are running for the right mapped volumes via device ids. 

### DEVELOPER IMPACT
* None
### Contribution Checklist
* [x] All changes have been reflected in comparable unit test changes or additions.
* [x] Any interactions with third party clients are done via interface types rather than direct interactions.
* [x] All new functions follow the required naming standard.
* [x] All new functions follow the required signature standards.

### PIC
![Embed something funny here](https://giphy.com/trending-gifs)