### PR TITLE
Add AssertRoute53ZoneIsAssociatedWithVPC and Bug Fixes

### DIFF
--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -622,16 +622,9 @@ func TestGetEC2InstancesByTag(t *testing.T) {
 func TestAssertEC2InstancesSubnetBalanced_Balanced(t *testing.T) {
 	subnetID1 := "s123456"
 	subnetID2 := "s7891011"
-	subnets := []types.Subnet{
-		{
-			SubnetId: &subnetID1,
-		},
-		{
-			SubnetId: &subnetID2,
-		},
-	}
 	instanceID1 := "a123456"
 	instanceID2 := "b123456"
+
 	instances := []types.Instance{
 		{
 			InstanceId: &instanceID1,
@@ -642,28 +635,16 @@ func TestAssertEC2InstancesSubnetBalanced_Balanced(t *testing.T) {
 			SubnetId:   &subnetID2,
 		},
 	}
-	input := AssertEC2InstancesSubnetBalancedInput{
-		Instances: instances,
-		Subnets:   subnets,
-	}
 	fakeTest := &testing.T{}
 	ctx := context.Background()
 
-	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, instances)
 	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2InstancesSubnetBalanced_Unbalanced(t *testing.T) {
 	subnetID1 := "s123456"
 	subnetID2 := "s7891011"
-	subnets := []types.Subnet{
-		{
-			SubnetId: &subnetID1,
-		},
-		{
-			SubnetId: &subnetID2,
-		},
-	}
 	instanceID1 := "a123456"
 	instanceID2 := "b123456"
 	instanceID3 := "c123456"
@@ -686,20 +667,15 @@ func TestAssertEC2InstancesSubnetBalanced_Unbalanced(t *testing.T) {
 			SubnetId:   &subnetID2,
 		},
 	}
-	input := AssertEC2InstancesSubnetBalancedInput{
-		Instances: instances,
-		Subnets:   subnets,
-	}
 	fakeTest := &testing.T{}
 	ctx := context.Background()
 
-	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, instances)
 	assert.True(t, fakeTest.Failed())
 }
 
 func TestAssertEC2InstancesSubnetBalanced_SingleSubnet(t *testing.T) {
 	subnetID1 := "s123456"
-	subnets := []types.Subnet{{SubnetId: &subnetID1}}
 	instanceID1 := "a123456"
 	instanceID2 := "b123456"
 	instanceID3 := "c123456"
@@ -717,28 +693,15 @@ func TestAssertEC2InstancesSubnetBalanced_SingleSubnet(t *testing.T) {
 			SubnetId:   &subnetID1,
 		},
 	}
-	input := AssertEC2InstancesSubnetBalancedInput{
-		Instances: instances,
-		Subnets:   subnets,
-	}
 	fakeTest := &testing.T{}
 	ctx := context.Background()
 
-	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, instances)
 	assert.False(t, fakeTest.Failed())
 }
 
 func TestAssertEC2InstancesSubnetBalanced_SingleEC2Instance(t *testing.T) {
 	subnetID1 := "s123456"
-	subnetID2 := "s7891011"
-	subnets := []types.Subnet{
-		{
-			SubnetId: &subnetID1,
-		},
-		{
-			SubnetId: &subnetID2,
-		},
-	}
 	instanceID1 := "a123456"
 	instances := []types.Instance{
 		{
@@ -746,40 +709,25 @@ func TestAssertEC2InstancesSubnetBalanced_SingleEC2Instance(t *testing.T) {
 			SubnetId:   &subnetID1,
 		},
 	}
-	input := AssertEC2InstancesSubnetBalancedInput{
-		Instances: instances,
-		Subnets:   subnets,
-	}
 	fakeTest := &testing.T{}
 	ctx := context.Background()
 
-	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, instances)
 	assert.False(t, fakeTest.Failed())
 }
 
-func TestAssertEC2InstancesSubnetBalanced_EmptySubnetList(t *testing.T) {
-	subnetID1 := "s123456"
-	subnetID2 := "s7891011"
+func TestAssertEC2InstancesSubnetBalanced_NoSubnets(t *testing.T) {
 	instanceID1 := "a123456"
-	instanceID2 := "a123456"
 	instances := []types.Instance{
 		{
 			InstanceId: &instanceID1,
-			SubnetId:   &subnetID1,
 		},
-		{
-			InstanceId: &instanceID2,
-			SubnetId:   &subnetID2,
-		},
-	}
-	input := AssertEC2InstancesSubnetBalancedInput{
-		Instances: instances,
 	}
 	fakeTest := &testing.T{}
 	ctx := context.Background()
 
-	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
-	assert.False(t, fakeTest.Failed())
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, instances)
+	assert.True(t, fakeTest.Failed())
 }
 
 func TestCreateFiltersFromMap(t *testing.T) {

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -619,7 +619,41 @@ func TestGetEC2InstancesByTag(t *testing.T) {
 	assert.ElementsMatch(t, expectedOutput, actualOutput, "getEC2InstancesByTagE did not return the expected results")
 }
 
-func TestAssertEC2InstancesSubnetBalanced_Matched(t *testing.T) {
+func TestAssertEC2InstancesSubnetBalanced_Balanced(t *testing.T) {
+	subnetID1 := "s123456"
+	subnetID2 := "s7891011"
+	subnets := []types.Subnet{
+		{
+			SubnetId: &subnetID1,
+		},
+		{
+			SubnetId: &subnetID2,
+		},
+	}
+	instanceID1 := "a123456"
+	instanceID2 := "b123456"
+	instances := []types.Instance{
+		{
+			InstanceId: &instanceID1,
+			SubnetId:   &subnetID1,
+		},
+		{
+			InstanceId: &instanceID2,
+			SubnetId:   &subnetID2,
+		},
+	}
+	input := AssertEC2InstancesSubnetBalancedInput{
+		Instances: instances,
+		Subnets:   subnets,
+	}
+	fakeTest := &testing.T{}
+	ctx := context.Background()
+
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	assert.False(t, fakeTest.Failed())
+}
+
+func TestAssertEC2InstancesSubnetBalanced_Unbalanced(t *testing.T) {
 	subnetID1 := "s123456"
 	subnetID2 := "s7891011"
 	subnets := []types.Subnet{
@@ -633,6 +667,7 @@ func TestAssertEC2InstancesSubnetBalanced_Matched(t *testing.T) {
 	instanceID1 := "a123456"
 	instanceID2 := "b123456"
 	instanceID3 := "c123456"
+	instanceID4 := "d123456"
 	instances := []types.Instance{
 		{
 			InstanceId: &instanceID1,
@@ -641,6 +676,41 @@ func TestAssertEC2InstancesSubnetBalanced_Matched(t *testing.T) {
 		{
 			InstanceId: &instanceID2,
 			SubnetId:   &subnetID2,
+		},
+		{
+			InstanceId: &instanceID3,
+			SubnetId:   &subnetID2,
+		},
+		{
+			InstanceId: &instanceID4,
+			SubnetId:   &subnetID2,
+		},
+	}
+	input := AssertEC2InstancesSubnetBalancedInput{
+		Instances: instances,
+		Subnets:   subnets,
+	}
+	fakeTest := &testing.T{}
+	ctx := context.Background()
+
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	assert.True(t, fakeTest.Failed())
+}
+
+func TestAssertEC2InstancesSubnetBalanced_SingleSubnet(t *testing.T) {
+	subnetID1 := "s123456"
+	subnets := []types.Subnet{{SubnetId: &subnetID1}}
+	instanceID1 := "a123456"
+	instanceID2 := "b123456"
+	instanceID3 := "c123456"
+	instances := []types.Instance{
+		{
+			InstanceId: &instanceID1,
+			SubnetId:   &subnetID1,
+		},
+		{
+			InstanceId: &instanceID2,
+			SubnetId:   &subnetID1,
 		},
 		{
 			InstanceId: &instanceID3,
@@ -655,7 +725,35 @@ func TestAssertEC2InstancesSubnetBalanced_Matched(t *testing.T) {
 	ctx := context.Background()
 
 	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	assert.False(t, fakeTest.Failed())
+}
 
+func TestAssertEC2InstancesSubnetBalanced_SingleEC2Instance(t *testing.T) {
+	subnetID1 := "s123456"
+	subnetID2 := "s7891011"
+	subnets := []types.Subnet{
+		{
+			SubnetId: &subnetID1,
+		},
+		{
+			SubnetId: &subnetID2,
+		},
+	}
+	instanceID1 := "a123456"
+	instances := []types.Instance{
+		{
+			InstanceId: &instanceID1,
+			SubnetId:   &subnetID1,
+		},
+	}
+	input := AssertEC2InstancesSubnetBalancedInput{
+		Instances: instances,
+		Subnets:   subnets,
+	}
+	fakeTest := &testing.T{}
+	ctx := context.Background()
+
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
 	assert.False(t, fakeTest.Failed())
 }
 

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -757,6 +757,31 @@ func TestAssertEC2InstancesSubnetBalanced_SingleEC2Instance(t *testing.T) {
 	assert.False(t, fakeTest.Failed())
 }
 
+func TestAssertEC2InstancesSubnetBalanced_EmptySubnetList(t *testing.T) {
+	subnetID1 := "s123456"
+	subnetID2 := "s7891011"
+	instanceID1 := "a123456"
+	instanceID2 := "a123456"
+	instances := []types.Instance{
+		{
+			InstanceId: &instanceID1,
+			SubnetId:   &subnetID1,
+		},
+		{
+			InstanceId: &instanceID2,
+			SubnetId:   &subnetID2,
+		},
+	}
+	input := AssertEC2InstancesSubnetBalancedInput{
+		Instances: instances,
+	}
+	fakeTest := &testing.T{}
+	ctx := context.Background()
+
+	AssertEC2InstancesBalancedInSubnets(fakeTest, ctx, input)
+	assert.False(t, fakeTest.Failed())
+}
+
 func TestCreateFiltersFromMap(t *testing.T) {
 	filterKey := "key"
 	filterKey2 := "otherkey"

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -106,10 +106,9 @@ func AssertRoute53ZoneIsAssociatedWithVPC(t *testing.T, ctx context.Context, cli
 			zones = append(zones, *zone.Name)
 		}
 
-		if output.NextToken == nil {
+		input.NextToken = output.NextToken
+		if input.NextToken == nil {
 			break
-		} else {
-			input.NextToken = output.NextToken
 		}
 	}
 


### PR DESCRIPTION
### SUMMARY
This PR...
- Adds the function `AssertRoute53ZoneIsAssociatedWithVPC` to assert that a R53 zone and VPC are associated with one another.
- Fixes a bug when comparing record types in `AssertRoute53RecordExistsInHostedZone`
- Takes a first pass at issue #17 by re-working `AssertEC2InstancesBalancedInSubnets` to not depend on the ordering of the instances and subnets